### PR TITLE
Deprecate this extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-# Azure Functions Tools - Extensions for VS Code
+# [DEPRECATED] Azure Functions Tools - Extensions for VS Code
  Azure Functions Tools - Extensions for VS Code
+
+> NOTE: This extension is deprecated. Please use [this Azure Functions extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurefunctions) instead.
 
 ## Features
 This extension for Visual Studio Code includes:

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "azure-functions-tools",
-  "displayName": "Azure Functions Tools",
-  "version": "0.3.1",
-  "description": "Azure Functions JSON Intellisense for VS Code",
+  "displayName": "[DEPRECATED] Azure Functions Tools",
+  "version": "0.3.2",
+  "description": "[DEPRECATED] Azure Functions JSON Intellisense for VS Code",
   "publisher": "johnpapa",
   "engines": {
     "vscode": "^1.10.0"
@@ -13,10 +13,6 @@
     "theme": "dark"
   },
   "license": "SEE LICENSE IN LICENSE.md",
-  "categories": [
-    "Other",
-    "Azure"
-  ],
   "contributes": {
     "snippets": [
       {
@@ -43,13 +39,6 @@
       }
     ]
   },
-  "keywords": [
-    "Azure",
-    "Azure Functions",
-    "JavaScript",
-    "Node",
-    "Node.js"
-  ],
   "scripts": {
     "postinstall": "node ./node_modules/vscode/bin/install"
   },


### PR DESCRIPTION
Deprecate in favor of [this extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurefunctions), which supersedes this in functionality and has 'Microsoft' as the publisher.

I removed the categories/keywords so that it hopefully shows up in fewer searches.